### PR TITLE
added initial gentoo support

### DIFF
--- a/dovecot/init.sls
+++ b/dovecot/init.sls
@@ -1,12 +1,10 @@
 {% from "dovecot/map.jinja" import dovecot with context %}
 
-{% if grains['os_family'] == 'Debian' %}
-
 dovecot_packages:
   pkg.installed:
     - names:
 {% for name in dovecot.packages %}
-      - dovecot-{{ name }}
+      - {{ name }}
 {% endfor %}
     - watch_in:
       - service: dovecot_service
@@ -65,4 +63,3 @@ dovecot_service:
       - pkg: dovecot_packages
     - require:
       - pkg: dovecot_packages
-{% endif %}

--- a/dovecot/map.jinja
+++ b/dovecot/map.jinja
@@ -6,6 +6,15 @@
             'confext': {},
             'conf': {},
             },
-        'packages': ['imapd'],
+        'packages': ['dovecot-imapd'],
+    },
+    'Gentoo': {
+        'config': {
+            'local': '# no customization',
+            'dovecotext': {},
+            'confext': {},
+            'conf': {},
+            },
+        'packages': ['net-mail/dovecot'],
     },
 }, merge=salt['pillar.get']('dovecot:lookup')) %}


### PR DESCRIPTION
I think the "if .... Debian" init init.sls is not required, I also had to put full package names into the jinja map for Debian because the package is just called different in gentoo.

Additional note: This way to configure dovecot actually looks like "the debian way" but AFAIK is not. Its like dovecot comes upstream. The files are the same in Gentoo for example where packages tend to be very close to upstream.
