### PR TITLE
Allow users to install extra packages

### DIFF
--- a/dovecot/init.sls
+++ b/dovecot/init.sls
@@ -2,7 +2,7 @@
 
 dovecot_packages:
   pkg.installed:
-    - pkgs: {{ dovecot.packages }}
+    - pkgs: {{ dovecot.packages + salt['pillar.get']('dovecot:extra_packages', []) }}
     - watch_in:
       - service: dovecot_service
 

--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,7 @@
 dovecot:
+  extra_packages:
+    - dovecot-sieve
+
   lookup:
     enable_service_control: True
     config:


### PR DESCRIPTION
This adjustment allows us to install extra packages (e.g. common stuff like dovecot-sieve or dovecot-lmtp).