### PR TITLE
Tighten permissions for /etc/dovecot/*.ext.conf files

### DIFF
--- a/dovecot/init.sls
+++ b/dovecot/init.sls
@@ -22,6 +22,9 @@ dovecot_packages:
     - contents: |
         {{ content | indent(8) }}
     - backup: minion
+    - user: root
+    - group: root
+    - mode: 600
     - watch_in:
       - service: dovecot_service
     - require:


### PR DESCRIPTION
These files are generally used to define SQL or LDAP commands and as such
also contain SQL or LDAP credentials.
Ensure these files are root owned and not world readable.