### PR TITLE
Persistent service

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,9 +2,9 @@
 dovecot-formula
 ===============
 
-A salt formula that installs and configures the dovecot IMAP server. It currently supports Debian
-or Ubuntu layout of the dovecot configuration files in /etc. Dovecot packages must be specified (imapd is installed by
-default if nothing is specified in pillar). Config file content (where needed) is stored in pillar (see pillar.example).
+A salt formula that installs and configures the dovecot IMAP server. It currently supports an Arch, Debian/Ubuntu, Gentoo or
+Red Hat styled layout of the dovecot configuration files in /etc. 
+Config file content (where needed) is stored in pillar (see pillar.example).
 
 Config file to pillar mappings:
 ===============================

--- a/dovecot/init.sls
+++ b/dovecot/init.sls
@@ -90,6 +90,9 @@ dovecot_service:
       - pkg: dovecot_packages
     - require:
       - pkg: dovecot_packages
+{% if dovecot.get('service_persistent', True) %}
+    - enable: True
+{% endif %}
 {% if 'enable_service_control' in dovecot and dovecot.enable_service_control == false %}
     # never run this state
     - onlyif:

--- a/pillar.example
+++ b/pillar.example
@@ -4,6 +4,7 @@ dovecot:
 
   lookup:
     enable_service_control: True
+    service_persistent: True
     config:
       local: |
         # main


### PR DESCRIPTION
The dovecot service is currently started, but not enabled. This means that after a reboot, the service is not running.

Change this behavior to enable the service by default, which can be overridden by setting the dovecot:service_persistent pillar to False.

Drive-By: Update the README.rst file to accurately mirror the current state of the formula, specifically the supported OS variants.