### PR TITLE
remove the jinja rendering tags in pillar.example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -114,7 +114,7 @@ dovecot:
       # - https://wiki.dovecot.org/AuthDatabase/PasswdFile
       # - https://wiki.dovecot.org/Authentication/PasswordSchemes
       passwd_files:
-        # Will create {{ dovecot.config.base }}/auth.d/example.tld.passwd
+        # Will create ''dovecot.config.base''/auth.d/example.tld.passwd
         example.tld: |
           user1:{BLF-CRYPT}HASH
           user2:{BLF-CRYPT}HASH::::::allow_nets=192.168.0.0/24


### PR DESCRIPTION
I've found that when the pillar is rendered, it fails due to this jinja tag. I'm assuming it's because dovecot.config.base is normally defined in the map, which isn't available when rendering the pillar directly.