### PR TITLE
fix(service): restart service on package change

### DIFF
--- a/dovecot/init.sls
+++ b/dovecot/init.sls
@@ -124,3 +124,14 @@ dovecot_service:
       - /bin/false
 {% endif %}
 
+# This is just here so we can force a restart via a watch_in.
+dovecot_service_restart:
+  service.running:
+    - name: dovecot
+    - watch:
+      - pkg: dovecot_packages
+{% if 'enable_service_control' in dovecot and dovecot.enable_service_control == false %}
+    # never run this state
+    - onlyif:
+      - /bin/false
+{% endif %}


### PR DESCRIPTION
On some occasions Dovecot needs to be restarted. For example: My Dovecot lead Postfix to bounce emails because the TLS certificate was changed, but the service rather reloaded than restarted.

Tested on FreeBSD 11.2 and Debian 10.