### PR TITLE
Optional generation of Diffie-Hellman Parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,3 +37,8 @@ Available states
 ------------
 
 Installs and configures the dovecot package, and ensures that the associated dovecot service is running.
+
+``dovecot.dh``
+--------------
+
+Creates Diffie-Hellman Parameters at the path defined in Pillar `dovecot:ssl:dhparam:path`.

--- a/dovecot/dh.sls
+++ b/dovecot/dh.sls
@@ -1,0 +1,8 @@
+{%- from "dovecot/map.jinja" import dovecot with context %}
+
+dovecot-dh-create-dhparam-file:
+  cmd.run:
+    - name: "openssl dhparam {{ dovecot.ssl.dhparam.numbits }} > {{ dovecot.ssl.dhparam.path }}"
+    - creates: {{ dovecot.ssl.dhparam.path }}
+    - watch_in:
+      - service: dovecot_service

--- a/dovecot/map.jinja
+++ b/dovecot/map.jinja
@@ -77,6 +77,12 @@
             'ssl_certs_dir': '/usr/local/etc/ssl/certs',
             'ssl_keys_dir': '/usr/local/etc/ssl/private',
            },
+        'ssl': {
+            'dhparam': {
+                'path': '/usr/local/etc/dovecot/dh.pem',
+                'numbits': 2048
+            }
+          },
         'packages': ['dovecot'],
         'root_group': 'wheel',
     },
@@ -93,6 +99,12 @@
             'ssl_certs_dir': '/etc/ssl/private',
             'ssl_keys_dir': '/etc/ssl/private',
            },
+        'ssl': {
+            'dhparam': {
+                'path': '/etc/dovecot/dh.pem',
+                'numbits': 2048
+            }
+          },
         'packages': ['dovecot-core','dovecot-imapd'],
         'root_group': 'root',
     },

--- a/pillar.example
+++ b/pillar.example
@@ -5,6 +5,10 @@ dovecot:
   lookup:
     enable_service_control: True
     service_persistent: True
+    ssl:
+      dhparam:
+        path: /etc/dovecot/dh.pem
+        numbits: 2048
     config:
       local: |
         # main


### PR DESCRIPTION
New since Dovecot 2.3.

From the mail log:

```
Jul 25 20:27:00 node2 dovecot: config: Warning: please set ssl_dh=</etc/dovecot/dh.pem                               
Jul 25 20:27:00 node2 dovecot: config: Warning: You can generate it with: dd if=/var/lib/dovecot/ssl-parameters.dat bs=1 skip=88 | openssl dhparam -inform der > /etc/dovecot/dh.pem
```

* https://wiki2.dovecot.org/Upgrading/2.3
* https://docs.iredmail.org/upgrade.dovecot.2.2-2.3.html

----

Tested on FreeBSD 11.2 and Debian 10.